### PR TITLE
Update Footer.module.css

### DIFF
--- a/components/footer/Footer.module.css
+++ b/components/footer/Footer.module.css
@@ -170,6 +170,10 @@
     display: flex;
     flex-direction: column;
   }
+
+.footerAbout {
+    margin-right:10px;
+}
   
   .footer .footerEvents {
     flex: 30%;


### PR DESCRIPTION
In the footer section of home page, "About Us" paragraph and "Links" 's are very close to each other in laptop 110% screen size, so i just margin right the about us section by 10px.